### PR TITLE
Add lxml missing requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 mechanize
 bs4
+lxml


### PR DESCRIPTION
It fixes the error "bs4.FeatureNotFound: Couldn't find a tree builder with the features you requested: lxml. Do you need to install a parser library?"